### PR TITLE
Add prompt weight support in the format of (subprompt:1.1)

### DIFF
--- a/nataili/inference/compvis.py
+++ b/nataili/inference/compvis.py
@@ -6,7 +6,6 @@ import numpy as np
 import PIL
 import skimage
 import torch
-from . import prompt_weights
 from einops import rearrange
 from slugify import slugify
 from transformers import CLIPFeatureExtractor
@@ -24,6 +23,8 @@ from nataili.util.performance import performance
 from nataili.util.process_prompt_tokens import process_prompt_tokens
 from nataili.util.save_sample import save_sample
 from nataili.util.seed_to_int import seed_to_int
+
+from . import prompt_weights
 
 try:
     from nataili.util.voodoo import load_from_plasma
@@ -354,8 +355,12 @@ class CompVis:
                         if isinstance(prompts, tuple):
                             prompts = list(prompts)
 
-                        c = torch.cat([prompt_weights.get_learned_conditioning_with_prompt_weights(prompt, model)
-                                      for prompt in prompts])
+                        c = torch.cat(
+                            [
+                                prompt_weights.get_learned_conditioning_with_prompt_weights(prompt, model)
+                                for prompt in prompts
+                            ]
+                        )
 
                         opt_C = 4
                         opt_f = 8
@@ -456,8 +461,12 @@ class CompVis:
                     if isinstance(prompts, tuple):
                         prompts = list(prompts)
 
-                    c = torch.cat([prompt_weights.get_learned_conditioning_with_prompt_weights(prompt, self.model)
-                                  for prompt in prompts])
+                    c = torch.cat(
+                        [
+                            prompt_weights.get_learned_conditioning_with_prompt_weights(prompt, self.model)
+                            for prompt in prompts
+                        ]
+                    )
 
                     opt_C = 4
                     opt_f = 8

--- a/nataili/inference/compvis.py
+++ b/nataili/inference/compvis.py
@@ -6,6 +6,7 @@ import numpy as np
 import PIL
 import skimage
 import torch
+from . import prompt_weights
 from einops import rearrange
 from slugify import slugify
 from transformers import CLIPFeatureExtractor
@@ -353,7 +354,8 @@ class CompVis:
                         if isinstance(prompts, tuple):
                             prompts = list(prompts)
 
-                        c = model.get_learned_conditioning(prompts)
+                        c = torch.cat([prompt_weights.get_learned_conditioning_with_prompt_weights(prompt, model)
+                                      for prompt in prompts])
 
                         opt_C = 4
                         opt_f = 8
@@ -454,7 +456,8 @@ class CompVis:
                     if isinstance(prompts, tuple):
                         prompts = list(prompts)
 
-                    c = self.model.get_learned_conditioning(prompts)
+                    c = torch.cat([prompt_weights.get_learned_conditioning_with_prompt_weights(prompt, self.model)
+                                  for prompt in prompts])
 
                     opt_C = 4
                     opt_f = 8

--- a/nataili/inference/prompt_weights.py
+++ b/nataili/inference/prompt_weights.py
@@ -5,6 +5,7 @@ from nataili.util import logger
 # When using prompt weights, use this to recover the original non-weighted prompt
 prompt_filter_regex = r"[\(\)]|:\d+(\.\d+)?"
 
+
 # We subtract the conditioning of the full prompt without the subprompt, from the conditioning of the full prompt
 # The remainder is exactly what the subprompt 'adds' to the embedding vector in the context of the full prompt
 # Then, we use this value to update the current embedding vector according to the desired weight of the subprompt

--- a/nataili/inference/prompt_weights.py
+++ b/nataili/inference/prompt_weights.py
@@ -1,0 +1,56 @@
+import re
+from nataili.util import logger
+
+# When using prompt weights, use this to recover the original non-weighted prompt
+prompt_filter_regex = r'[\(\)]|:\d+(\.\d+)?'
+
+# We subtract the conditioning of the full prompt without the subprompt, from the conditioning of the full prompt
+# The remainder is exactly what the subprompt 'adds' to the embedding vector in the context of the full prompt
+# Then, we use this value to update the current embedding vector according to the desired weight of the subprompt
+def update_conditioning(filtered_whole_prompt, filtered_whole_prompt_c, model, current_prompt_c, subprompt, weight):
+    prompt_wo_subprompt = filtered_whole_prompt.replace(subprompt, "")
+    prompt_wo_subprompt_c = model.get_learned_conditioning(prompt_wo_subprompt)
+    subprompt_contribution_to_c = filtered_whole_prompt_c - prompt_wo_subprompt_c
+    current_prompt_c += (weight - 1.0) * subprompt_contribution_to_c
+    return current_prompt_c
+
+
+def get_learned_conditioning_with_prompt_weights(prompt, model):
+    # Get a filtered prompt without (, ), and :number + conditioning
+    filtered_whole_prompt = re.sub(prompt_filter_regex, '', prompt)
+
+    # Get full prompt embedding vector
+    filtered_whole_prompt_c = model.get_learned_conditioning(filtered_whole_prompt)
+    current_prompt_c = filtered_whole_prompt_c
+
+    # Find the first () delimited subprompt
+    subprompt_open_i = prompt.find("(")
+    subprompt_close_i = prompt.find(")", subprompt_open_i+1)
+
+    # Process the (next) subprompt
+    while subprompt_open_i != -1 and subprompt_close_i != -1:
+        subprompt = prompt[subprompt_open_i + 1 : subprompt_close_i]
+        weight_i = subprompt.find(":")
+        subprompt_wo_weight = subprompt[0:weight_i]
+
+        # Process the weight if we have it
+        if weight_i != -1:
+            weight_str = subprompt[weight_i + 1:]
+            try:
+                weight_val = float(weight_str)
+                # Update the conditioning with this subprompt and weight
+                logger.debug(f"Adjusting subprompt weight to {weight_val}")
+                current_prompt_c = update_conditioning(filtered_whole_prompt,
+                                                       filtered_whole_prompt_c,
+                                                       model,
+                                                       current_prompt_c,
+                                                       subprompt_wo_weight,
+                                                       weight_val)
+            except ValueError:
+                pass
+
+        # Find next () delimited subprompt
+        subprompt_open_i = prompt.find("(", subprompt_open_i+1)
+        subprompt_close_i = prompt.find(")", subprompt_open_i+1)
+
+    return current_prompt_c

--- a/nataili/inference/prompt_weights.py
+++ b/nataili/inference/prompt_weights.py
@@ -1,8 +1,9 @@
 import re
+
 from nataili.util import logger
 
 # When using prompt weights, use this to recover the original non-weighted prompt
-prompt_filter_regex = r'[\(\)]|:\d+(\.\d+)?'
+prompt_filter_regex = r"[\(\)]|:\d+(\.\d+)?"
 
 # We subtract the conditioning of the full prompt without the subprompt, from the conditioning of the full prompt
 # The remainder is exactly what the subprompt 'adds' to the embedding vector in the context of the full prompt
@@ -17,7 +18,7 @@ def update_conditioning(filtered_whole_prompt, filtered_whole_prompt_c, model, c
 
 def get_learned_conditioning_with_prompt_weights(prompt, model):
     # Get a filtered prompt without (, ), and :number + conditioning
-    filtered_whole_prompt = re.sub(prompt_filter_regex, '', prompt)
+    filtered_whole_prompt = re.sub(prompt_filter_regex, "", prompt)
 
     # Get full prompt embedding vector
     filtered_whole_prompt_c = model.get_learned_conditioning(filtered_whole_prompt)
@@ -25,7 +26,7 @@ def get_learned_conditioning_with_prompt_weights(prompt, model):
 
     # Find the first () delimited subprompt
     subprompt_open_i = prompt.find("(")
-    subprompt_close_i = prompt.find(")", subprompt_open_i+1)
+    subprompt_close_i = prompt.find(")", subprompt_open_i + 1)
 
     # Process the (next) subprompt
     while subprompt_open_i != -1 and subprompt_close_i != -1:
@@ -35,22 +36,24 @@ def get_learned_conditioning_with_prompt_weights(prompt, model):
 
         # Process the weight if we have it
         if weight_i != -1:
-            weight_str = subprompt[weight_i + 1:]
+            weight_str = subprompt[weight_i + 1 :]
             try:
                 weight_val = float(weight_str)
                 # Update the conditioning with this subprompt and weight
                 logger.debug(f"Adjusting subprompt weight to {weight_val}")
-                current_prompt_c = update_conditioning(filtered_whole_prompt,
-                                                       filtered_whole_prompt_c,
-                                                       model,
-                                                       current_prompt_c,
-                                                       subprompt_wo_weight,
-                                                       weight_val)
+                current_prompt_c = update_conditioning(
+                    filtered_whole_prompt,
+                    filtered_whole_prompt_c,
+                    model,
+                    current_prompt_c,
+                    subprompt_wo_weight,
+                    weight_val,
+                )
             except ValueError:
                 pass
 
         # Find next () delimited subprompt
-        subprompt_open_i = prompt.find("(", subprompt_open_i+1)
-        subprompt_close_i = prompt.find(")", subprompt_open_i+1)
+        subprompt_open_i = prompt.find("(", subprompt_open_i + 1)
+        subprompt_close_i = prompt.find(")", subprompt_open_i + 1)
 
     return current_prompt_c

--- a/worker/jobs/stable_diffusion.py
+++ b/worker/jobs/stable_diffusion.py
@@ -260,7 +260,7 @@ class StableDiffusionHordeJob(HordeJobFramework):
             logger.debug("Starting generation...")
             generator.generate(**gen_payload)
             logger.debug("Finished generation...")
-        except (RuntimeError,ValueError,AttributeError) as err:
+        except (RuntimeError, ValueError, AttributeError) as err:
             stack_payload = gen_payload
             stack_payload["request_type"] = req_type
             stack_payload["model"] = self.current_model


### PR DESCRIPTION
For example:
A photograph of an (astronaut:1.2) riding a horse on the moon

I've been looking for a good code example to add prompt weights, but most implementations I found just split the prompt in subprompts, and make a weighted average of the embeddings of these subprompts. This has two disadvantages:

- Even adding a small weight tweak to one of the words changes the image completely
- Since the prompt is split, information about the context between words is lost. (which is exactly what transformers are good at)

This implementation takes a different approach; It calculates the difference between the whole prompt with and without the weighted subprompt. It takes this difference to be the contribution of the subprompt to the embedding vector, and uses this to subtly modify the original embedding vector on the weight. Results seem much more stable (small tweaks don't disturb the entire result), and I believe this to be a better method.

I'm pretty new to this, so:
- Please test
- Feedback welcome!