### PR TITLE
[bug] enabling inpainting occasionally puts worker in maintenance mode

### DIFF
--- a/worker/bridge_data/stable_diffusion.py
+++ b/worker/bridge_data/stable_diffusion.py
@@ -11,6 +11,8 @@ from worker.bridge_data.framework import BridgeDataTemplate
 class StableDiffusionBridgeData(BridgeDataTemplate):
     """Configuration object"""
 
+    POSTPROCESSORS = ["GFPGAN", "RealESRGAN_x4plus", "CodeFormers"]
+
     def __init__(self):
         super().__init__(args)
         self.max_power = int(os.environ.get("HORDE_MAX_POWER", 8))
@@ -119,9 +121,7 @@ class StableDiffusionBridgeData(BridgeDataTemplate):
         # if self.censor_nsfw or (self.censorlist is not None and len(self.censorlist)):
         self.model_names.append("safety_checker")
         if self.allow_post_processing:
-            self.model_names.append("GFPGAN")
-            self.model_names.append("RealESRGAN_x4plus")
-            self.model_names.append("CodeFormers")
+            self.model_names += self.POSTPROCESSORS
         if (not self.initialized and not self.models_reloading) or previous_url != self.horde_url:
             logger.init(
                 (

--- a/worker/jobs/stable_diffusion.py
+++ b/worker/jobs/stable_diffusion.py
@@ -12,6 +12,7 @@ from nataili.inference.compvis import CompVis
 from nataili.inference.diffusers.depth2img import Depth2Img
 from nataili.inference.diffusers.inpainting import inpainting
 from nataili.util import logger
+from worker.bridge_data.stable_diffusion import StableDiffusionBridgeData
 from worker.enums import JobStatus
 from worker.jobs.framework import HordeJobFramework
 from worker.post_process import post_process
@@ -121,8 +122,17 @@ class StableDiffusionHordeJob(HordeJobFramework):
         ]:
             # Try to find any other model to do text2img or img2img
             for available_model in self.available_models:
-                if available_model != "stable_diffusion_inpainting":
+                if (
+                    available_model != "stable_diffusion_inpainting"
+                    and available_model not in StableDiffusionBridgeData.POSTPROCESSORS
+                ):
                     self.current_model = available_model
+                    logger.warning(
+                        "Model stable_diffusion_inpainting chosen for txt2img or img2img gen, "
+                        + f"switching to {self.current_model} instead."
+                    )
+                    break
+
             # if the model persists as inpainting for text2img or img2img, we abort.
             if self.current_model == "stable_diffusion_inpainting":
                 # We remove the base64 from the prompt to avoid flooding the output on the error


### PR DESCRIPTION
Fixes bug as reported in:
https://github.com/db0/AI-Horde/issues/133

If the 'inpainting' model is selected for either a txt2img or img2img generation, the worker would automatically select another model (at the end of the model list).

If this model so happens to be a post-processor, the generation would fail because these can't be used as model directly. If this happens too often in a row, the worker would be put in maintenance mode.