### PR TITLE
Fix queueing and threading, significantly improving performance

### DIFF
--- a/worker/workers/framework.py
+++ b/worker/workers/framework.py
@@ -38,7 +38,7 @@ class WorkerFramework:
                         self.process_jobs()
                     except KeyboardInterrupt:
                         self.should_stop = True
-                    break
+                        break
             if self.should_stop:
                 logger.init("Worker", status="Shutting Down")
                 try:


### PR DESCRIPTION
The main-loop would break every iteration. This would be caught by an outer shutdown loop, but because this would break out of a `with ThreadPoolExecutor:` scope, it would wait for all threads to finish before starting a new thread or even getting new requests in the queue.