### PR TITLE
Fixing xformers support for Pascal GPUs

### DIFF
--- a/ldm/modules/attention.py
+++ b/ldm/modules/attention.py
@@ -28,7 +28,7 @@ logger.init("xformers optimizations", status="Checking")
 if disable_xformers.active:
     xformers = None
     logger.init_err("xformers optimizations", status="Disabled")
-elif (7, 0) <= torch.cuda.get_device_capability(device) <= (9, 0):
+elif (6, 1) <= torch.cuda.get_device_capability(device) <= (9, 0):
     xformers_available = importlib.util.find_spec("xformers") is not None
     try:
         importlib_metadata.version("xformers")


### PR DESCRIPTION
The existing code doesn't allow Xformers to be loaded for CUDA version 6.1 GPUs (Pascal), even though they are supported. This new code corrects that, so that Pascal GPUs can use Xformers. Tested and working on my 1080ti.