### PR TITLE
Prevent downloading controlnet reference on each generation

### DIFF
--- a/bridge_stable_diffusion.py
+++ b/bridge_stable_diffusion.py
@@ -51,6 +51,7 @@ def main():
         gfpgan=True,
         safety_checker=True,
         codeformer=True,
+        controlnet=True,
     )
     try:
         worker = StableDiffusionWorker(model_manager, bridge_data)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-nataili
+nataili >= 0.2.9006
 xformers
 gradio

--- a/worker/jobs/stable_diffusion.py
+++ b/worker/jobs/stable_diffusion.py
@@ -269,6 +269,7 @@ class StableDiffusionHordeJob(HordeJobFramework):
                     safety_checker=safety_checker,
                     filter_nsfw=use_nsfw_censor,
                     disable_voodoo=self.bridge_data.disable_voodoo.active,
+                    control_net_manager=self.model_manager.controlnet if self.model_manager.controlnet else None,
                 )
         else:
             # These variables do not exist in the outpainting implementation


### PR DESCRIPTION
v0.2.9006 nataili adds controlnet to super manager, allowing controlnet manager to be passed into CompVis, and avoid downloading the Controlnet model database on each generation

Minimum version for Nataili set in requirements.txt, this should help with environments not updating, recommend minimum version of nataili is bumped when appropriate.

This version of AI-Horde-Worker in combination with v0.2.9006 Nataili is running on my worker.

