### PR TITLE
Conda Overhaul

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -15,28 +15,12 @@ name: ldm
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 channels:
-  - pytorch
+  - nvidia
+  - conda-forge
   - defaults
-  - nvidia/label/cuda-11.7.0
-# Psst. If you change a dependency, make sure it's mirrored in the docker requirement
-# files as well.
+# These should only contain the minimal essentials to get the binaries going, everything else is managed in requirements.txt to keep it universal.
 dependencies:
-  - cuda-toolkit
+  - cudatoolkit==11.7.0
   - git
-  - numpy
   - pip
-  - python~=3.10
-  - pytorch=1.13.1
-  - pytorch-cuda
-  - scikit-image
-  - torchvision
-  - loguru
-  - requests>=2.28
-  - numpy>=1.23
-  - pip:
-      - nataili==0.2.9009
-      - xformers
-      - gradio
-      - transformers>=4.26
-      - k-diffusion>=0.0.14
-
+  - python==3.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+--extra-index-url https://download.pytorch.org/whl/cu117
 nataili == 0.2.9009
 xformers
 gradio

--- a/runtime.cmd
+++ b/runtime.cmd
@@ -1,5 +1,7 @@
 @echo off
-cd /d %~dp0
+cd /d "%~dp0"
+
+SET CONDA_SHLVL=
 
 Reg add "HKLM\SYSTEM\CurrentControlSet\Control\FileSystem" /v "LongPathsEnabled" /t REG_DWORD /d "1" /f 2>nul
 IF EXIST CONDA GOTO APP

--- a/update-runtime.cmd
+++ b/update-runtime.cmd
@@ -1,8 +1,10 @@
 @echo off
-cd /d %~dp0
+cd /d "%~dp0"
 
 SET CONDA_SHLVL=
 
 Reg add "HKLM\SYSTEM\CurrentControlSet\Control\FileSystem" /v "LongPathsEnabled" /t REG_DWORD /d "1" /f 2>nul
 umamba create --no-shortcuts -r conda -n windows -f environment.yaml -y
+call conda\condabin\activate.bat windows
+pip install -r requirements.txt
 echo If there are no errors above everything should be correctly installed (If not, try running update_runtime.cmd as admin).

--- a/update-runtime.sh
+++ b/update-runtime.sh
@@ -5,3 +5,4 @@ if [ ! -f "conda/envs/linux/bin/python" ]; then
  bin/micromamba create --no-shortcuts -r conda -n linux -f environment.yaml -y
 fi
 bin/micromamba create --no-shortcuts -r conda -n linux -f environment.yaml -y
+bin/micromamba run -r conda -n linux pip install -r requirements.txt


### PR DESCRIPTION
Makes the dependencies for conda much simpler to deal with, especially since the old file: method broke.
Now the scripts just run pip manually for a more sustainable way, this does still need testing on Linux.
So merge it after its been successfully tested.

In the future both environments.yml and requirements.txt are very minimal containing only the essentials, so most of the management can be done upstream on the nataili package.