### PR TITLE
Conda workaround for Windows (Same as Linux)

### DIFF
--- a/update-runtime.cmd
+++ b/update-runtime.cmd
@@ -4,7 +4,10 @@ cd /d "%~dp0"
 SET CONDA_SHLVL=
 
 Reg add "HKLM\SYSTEM\CurrentControlSet\Control\FileSystem" /v "LongPathsEnabled" /t REG_DWORD /d "1" /f 2>nul
+:We do this twice the first time to workaround a conda bug where pip is not installed correctly the first time - Henk
+IF EXIST CONDA GOTO WORKAROUND_END
 umamba create --no-shortcuts -r conda -n windows -f environment.yaml -y
-call conda\condabin\activate.bat windows
-pip install -r requirements.txt
+:WORKAROUND_END
+umamba create --no-shortcuts -r conda -n windows -f environment.yaml -y
+umamba run -r conda -n windows pip install -r requirements.txt
 echo If there are no errors above everything should be correctly installed (If not, try running update_runtime.cmd as admin).


### PR DESCRIPTION
Turns out on the Windows side you have the same bug as on Linux where the first conda installation fails if the environment did not exist yet.
To fix this it now installs it twice on a new installation, since most of the dependencies are done by PIP and nothing is redownloaded this has minimal impact.