### PR TITLE
Adds comand line option --enable_model_cache

### DIFF
--- a/worker/argparser/framework.py
+++ b/worker/argparser/framework.py
@@ -130,6 +130,12 @@ arg_parser.add_argument(
     default=False,
     help="If specified will not check the downloaded model md5sum.",
 )
+arg_parser.add_argument(
+    "--enable_model_cache",
+    action="store_true",
+    default=False,
+    help="If specified will use an alternative to ray to cache models persistently.",
+)
 
 
 # This args must be parsed in the extended class

--- a/worker/argparser/stable_diffusion.py
+++ b/worker/argparser/stable_diffusion.py
@@ -1,5 +1,5 @@
 """Arg parsing for the main script."""
-from nataili import disable_progress, disable_voodoo, disable_xformers, enable_local_ray_temp
+from nataili import disable_progress, disable_voodoo, disable_xformers, enable_local_ray_temp, enable_ray_alternative
 
 from worker.argparser.framework import arg_parser
 
@@ -80,3 +80,4 @@ disable_voodoo.toggle(args.disable_voodoo)
 if disable_voodoo.active:
     enable_local_ray_temp.disable()
 disable_progress.activate()
+enable_ray_alternative.toggle(args.enable_model_cache)


### PR DESCRIPTION
This switch enables the model cache, the alternative to ray for use when loading huge numbers of models.