### PR TITLE
update checksum args after MD5 deprecation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,6 +169,7 @@ nataili/**/*.bin
 nataili/**/*.txt
 nataili/**/*.yaml
 nataili/**/*.md5
+nataili/**/*.sha256
 nataili/**/*.safetensors
 nataili/embeds/*
 /outputs/

--- a/bridge_stable_diffusion.py
+++ b/bridge_stable_diffusion.py
@@ -62,6 +62,9 @@ def check_dependencies():
 def main():
     set_logger_verbosity(args.verbosity)
     quiesce_logger(args.quiet)
+    # TODO: Remove check after fully deprecating arg.
+    if args.skip_md5:
+        logger.warning("DeprecationWarning: `--skip_md5` has been deprecated. Please use `--skip_checksum` instead.")
 
     bridge_data = StableDiffusionBridgeData()
     model_manager = ModelManager(

--- a/worker/argparser/framework.py
+++ b/worker/argparser/framework.py
@@ -124,11 +124,18 @@ arg_parser.add_argument(
     required=False,
     help="Specify this argument to autodownload all missing models defined in your bridgeData.yaml",
 )
+# TODO: Remove arg after fully deprecating.
 arg_parser.add_argument(
     "--skip_md5",
     action="store_true",
     default=False,
     help="If specified will not check the downloaded model md5sum.",
+)
+arg_parser.add_argument(
+    "--skip_checksum",
+    action="store_true",
+    default=False,
+    help="If specified will not check the downloaded model sha256sum.",
 )
 arg_parser.add_argument(
     "--enable_model_cache",

--- a/worker/bridge_data/framework.py
+++ b/worker/bridge_data/framework.py
@@ -150,7 +150,8 @@ class BridgeDataTemplate:
                 continue
             if model in model_manager.get_loaded_models_names():
                 continue
-            if not model_manager.validate_model(model, skip_checksum=self.args.skip_md5):
+            # TODO: Remove `self.args.skip_md5 or ` after fully deprecating arg.
+            if not model_manager.validate_model(model, skip_checksum=self.args.skip_md5 or self.args.skip_checksum):
                 logger.debug(f"Model {model} not found or has wrong checksum")
                 if (
                     model not in model_manager.get_available_models_by_types()


### PR DESCRIPTION
Deprecate `--skip_md5` without immediately breaking bridge scripts.