### PR TITLE
Call python explicitly with a forced  no user packages (-s)

### DIFF
--- a/bridge-webui.cmd
+++ b/bridge-webui.cmd
@@ -1,4 +1,4 @@
 @echo off
 cd /d %~dp0
-call runtime python webui.py %*
+call runtime python -s webui.py %*
 %0 %*

--- a/bridge-webui.sh
+++ b/bridge-webui.sh
@@ -1,1 +1,1 @@
-./runtime.sh python webui.py $*
+./runtime.sh python -s webui.py $*

--- a/horde-bridge.cmd
+++ b/horde-bridge.cmd
@@ -1,5 +1,5 @@
 @echo off
 cd /d %~dp0
 set NATAILI_CACHE_HOME=./
-call runtime python bridge_stable_diffusion.py %*
+call runtime python -s bridge_stable_diffusion.py %*
 %0 %*

--- a/horde-bridge.sh
+++ b/horde-bridge.sh
@@ -1,2 +1,2 @@
 export NATAILI_CACHE_HOME="./"
-./runtime.sh python bridge_stable_diffusion.py $*
+./runtime.sh python -s bridge_stable_diffusion.py $*

--- a/horde-interrogation_bridge.cmd
+++ b/horde-interrogation_bridge.cmd
@@ -1,4 +1,4 @@
 @echo off
 cd /d %~dp0
-call runtime python bridge_interrogation.py %*
+call runtime python -s bridge_interrogation.py %*
 %0 %*

--- a/horde-interrogation_bridge.sh
+++ b/horde-interrogation_bridge.sh
@@ -1,1 +1,1 @@
-./runtime.sh python bridge_interrogation.py $*
+./runtime.sh python -s bridge_interrogation.py $*

--- a/show_available_models.cmd
+++ b/show_available_models.cmd
@@ -1,3 +1,3 @@
 @echo off
 cd /d %~dp0
-call runtime python show_available_models.py %*
+call runtime python -s show_available_models.py %*

--- a/show_available_models.sh
+++ b/show_available_models.sh
@@ -1,1 +1,1 @@
-./runtime.sh python show_available_models.py
+./runtime.sh python -s show_available_models.py

--- a/update-runtime.cmd
+++ b/update-runtime.cmd
@@ -12,5 +12,5 @@ IF EXIST CONDA GOTO WORKAROUND_END
 umamba create --no-shortcuts -r conda -n windows -f environment.yaml -y
 :WORKAROUND_END
 umamba create --no-shortcuts -r conda -n windows -f environment.yaml -y
-umamba run -r conda -n windows pip install -r requirements.txt
+umamba run -r conda -n windows python -s -m pip install -r requirements.txt
 echo If there are no errors above everything should be correctly installed (If not, try running update_runtime.cmd as admin).

--- a/update-runtime.sh
+++ b/update-runtime.sh
@@ -5,4 +5,4 @@ if [ ! -f "conda/envs/linux/bin/python" ]; then
  bin/micromamba create --no-shortcuts -r conda -n linux -f environment.yaml -y
 fi
 bin/micromamba create --no-shortcuts -r conda -n linux -f environment.yaml -y
-bin/micromamba run -r conda -n linux pip install -r requirements.txt
+bin/micromamba run -r conda -n linux python -s -m pip install -r requirements.txt


### PR DESCRIPTION
There is at least one case of the package isolation still not working as intended, this is a known fix for that case. As there is no circumstances I can think of to allow user packages, I am suggesting that python is called directly with the `-s` flag, and by convention, that becomes the normal way of things.