### PR TITLE
fix: Build/CI not running ruff correctly

### DIFF
--- a/style.py
+++ b/style.py
@@ -59,7 +59,6 @@ else:
     print("fix not requested")
 
     black_args.extend(("--check", "--diff"))
-    ruff_args.append("--diff")
 
 lint_processes = [
     ruff_args,


### PR DESCRIPTION
A bug slipped in where ruff was being called with `--diff` causing it to silently fail and not produce linting results.

I assumed ruff was reporting the results when I made the change to show diffs, when in fact it was black. 

This correct the issue.