### PR TITLE
use round() instead of int() for parsed RAM values

### DIFF
--- a/worker/ui.py
+++ b/worker/ui.py
@@ -83,7 +83,7 @@ class GPUInfo:
         if mem < 1:
             unit = "MB"
             raw *= 1024
-        return f"{int(mem)} {unit}"
+        return f"{round(mem)} {unit}"
 
     def get_info(self):
         data = self._get_gpu_data()


### PR DESCRIPTION
Round V/RAM displays to nearest unit instead of flooring