### PR TITLE
fix: defers cn annotator check until after config is loaded

### DIFF
--- a/bridge_scribe.py
+++ b/bridge_scribe.py
@@ -1,9 +1,8 @@
 """This is the bridge, It connects the horde with the ML processing"""
-import os
-
 # isort: off
 # We need to import the argparser first, as it sets the necessary Switches
 from worker.argparser.scribe import args
+
 # isort: on
 
 from worker.bridge_data.scribe import KoboldAIBridgeData

--- a/bridge_stable_diffusion.py
+++ b/bridge_stable_diffusion.py
@@ -61,15 +61,18 @@ def main():
         controlnet=True,
     )
 
-    if bridge_data.allow_controlnet:
-        annotators_preloaded_successfully = SharedModelManager.preloadAnnotators()
+    try:
+        worker = StableDiffusionWorker(SharedModelManager.manager, bridge_data)
+
+        annotators_preloaded_successfully = False
+        if bridge_data.allow_controlnet:
+            annotators_preloaded_successfully = SharedModelManager.preloadAnnotators()
         if not annotators_preloaded_successfully:
             logger.error("Annotators failed to preload. ControlNet will not be available.", status="Error")
             bridge_data.allow_controlnet = False
 
-    try:
-        worker = StableDiffusionWorker(SharedModelManager.manager, bridge_data)
         worker.start()
+
     except KeyboardInterrupt:
         logger.info("Keyboard Interrupt Received. Ending Process")
     logger.init(f"{bridge_data.worker_name} Instance", status="Stopped")

--- a/show_available_models.py
+++ b/show_available_models.py
@@ -3,8 +3,11 @@
 
 # isort: off
 import hordelib
+
 hordelib.initialise()
-from hordelib.horde import SharedModelManager
+
+from hordelib.horde import SharedModelManager  # noqa: E402
+
 # isort: on
 
 if __name__ == "__main__":

--- a/worker/bridge_data/scribe.py
+++ b/worker/bridge_data/scribe.py
@@ -1,14 +1,11 @@
 """The configuration of the bridge"""
 import os
-import re
-import time
 
 import requests
-from PIL import Image
+from loguru import logger
 
 from worker.argparser.scribe import args
 from worker.bridge_data.framework import BridgeDataTemplate
-from loguru import logger
 
 
 class KoboldAIBridgeData(BridgeDataTemplate):
@@ -57,19 +54,19 @@ class KoboldAIBridgeData(BridgeDataTemplate):
     def validate_kai(self):
         logger.debug("Retrieving settings from KoboldAI Client...")
         try:
-            req = requests.get(self.kai_url + '/api/latest/model')
+            req = requests.get(self.kai_url + "/api/latest/model")
             self.model = req.json()["result"]
             # Normalize huggingface and local downloaded model names
             if "/" not in self.model:
-                self.model = self.model.replace('_', '/', 1)
-            req = requests.get(self.kai_url + '/api/latest/config/max_context_length')
+                self.model = self.model.replace("_", "/", 1)
+            req = requests.get(self.kai_url + "/api/latest/config/max_context_length")
             self.max_context_length = req.json()["value"]
-            req = requests.get(self.kai_url + '/api/latest/config/max_length')
+            req = requests.get(self.kai_url + "/api/latest/config/max_length")
             self.max_length = req.json()["value"]
             if self.model not in self.softprompts:
-                    req = requests.get(self.kai_url + '/api/latest/config/soft_prompts_list')
-                    self.softprompts[self.model] = [sp['value'] for sp in req.json()["values"]]
-            req = requests.get(self.kai_url + '/api/latest/config/soft_prompt')
+                req = requests.get(self.kai_url + "/api/latest/config/soft_prompts_list")
+                self.softprompts[self.model] = [sp["value"] for sp in req.json()["values"]]
+            req = requests.get(self.kai_url + "/api/latest/config/soft_prompt")
             self.current_softprompt = req.json()["value"]
         except requests.exceptions.JSONDecodeError:
             logger.error(f"Server {self.kai_url} is up but does not appear to be a KoboldAI server.")
@@ -80,4 +77,3 @@ class KoboldAIBridgeData(BridgeDataTemplate):
             self.kai_available = False
             return
         self.kai_available = True
-    

--- a/worker/bridge_data/stable_diffusion.py
+++ b/worker/bridge_data/stable_diffusion.py
@@ -4,13 +4,13 @@ import re
 import time
 
 import requests
+from hordelib.settings import UserSettings
 from PIL import Image
 
 from worker.argparser.stable_diffusion import args
 from worker.bridge_data.framework import BridgeDataTemplate
 from worker.consts import KNOWN_INTERROGATORS, POST_PROCESSORS_HORDELIB_MODELS
 from worker.logger import logger
-from hordelib.settings import UserSettings
 
 
 class StableDiffusionBridgeData(BridgeDataTemplate):

--- a/worker/jobs/poppers.py
+++ b/worker/jobs/poppers.py
@@ -184,7 +184,6 @@ class StableDiffusionPopper(JobPopper):
         return Image.open(BytesIO(img_bytes))
 
 
-
 class ScribePopper(JobPopper):
     def __init__(self, mm, bd):
         super().__init__(mm, bd)

--- a/worker/jobs/scribe.py
+++ b/worker/jobs/scribe.py
@@ -1,9 +1,7 @@
 """Get and process a job from the horde"""
-import base64
+import json
 import time
 import traceback
-import json
-from io import BytesIO
 
 import requests
 
@@ -25,8 +23,8 @@ class ScribeHordeJob(HordeJobFramework):
         self.current_model = self.bridge_data.model
         self.current_id = self.pop["id"]
         self.current_payload = self.pop["payload"]
-        self.current_payload['quiet'] = True
-        self.requested_softprompt = self.current_payload.get('softprompt')
+        self.current_payload["quiet"] = True
+        self.requested_softprompt = self.current_payload.get("softprompt")
         self.censored = None
 
     @logger.catch(reraise=True)
@@ -40,8 +38,8 @@ class ScribeHordeJob(HordeJobFramework):
         self.stale_time = time.time() + (self.current_payload.get("max_length", 80) / 2) + 10
         # These params will always exist in the payload from the horde
         gen_payload = self.current_payload
-        if 'width' in gen_payload or 'length' in gen_payload or 'steps' in gen_payload:
-            logger.error("Stable Diffusion payload detected. Aborting. ({})", err)
+        if "width" in gen_payload or "length" in gen_payload or "steps" in gen_payload:
+            logger.error(f"Stable Diffusion payload detected. Aborting. ({gen_payload})")
             self.status = JobStatus.FAULTED
             self.start_submit_thread()
             return
@@ -53,47 +51,69 @@ class ScribeHordeJob(HordeJobFramework):
             )
             time_state = time.time()
             if self.requested_softprompt != self.bridge_data.current_softprompt:
-                req = requests.put(self.bridge_data.kai_url + '/api/latest/config/soft_prompt/', json = {"value": self.requested_softprompt})
-                time.sleep(1) # Wait a second to unload the softprompt
+                requests.put(
+                    self.bridge_data.kai_url + "/api/latest/config/soft_prompt/",
+                    json={"value": self.requested_softprompt},
+                )
+                time.sleep(1)  # Wait a second to unload the softprompt
             logger.debug(gen_payload)
             loop_retry = 0
             gen_success = False
             while not gen_success and loop_retry < 5:
                 try:
-                    gen_req = requests.post(self.bridge_data.kai_url + '/api/latest/generate/', json = self.current_payload, timeout=300)
+                    gen_req = requests.post(
+                        self.bridge_data.kai_url + "/api/latest/generate/",
+                        json=self.current_payload,
+                        timeout=300,
+                    )
                 except (requests.exceptions.ConnectionError, requests.exceptions.ReadTimeout):
                     logger.error(f"Worker {self.bridge_data.kai_url} unavailable. Retrying in 3 seconds...")
                     loop_retry += 1
                     time.sleep(3)
                     continue
                 if type(gen_req.json()) is not dict:
-                    logger.error(f'KAI instance {self.bridge_data.kai_url} API unexpected response on generate: {gen_req}. Retrying in 3 seconds...')
+                    logger.error(
+                        (
+                            f"KAI instance {self.bridge_data.kai_url} API unexpected response on generate: {gen_req}. "
+                            "Retrying in 3 seconds..."
+                        ),
+                    )
                     time.sleep(3)
                     loop_retry += 1
                     continue
                 if gen_req.status_code == 503:
-                    logger.debug(f'KAI instance {self.bridge_data.kai_url} Busy (attempt {loop_retry}). Will try again...')
+                    logger.debug(
+                        f"KAI instance {self.bridge_data.kai_url} Busy (attempt {loop_retry}). Will try again...",
+                    )
                     time.sleep(3)
                     loop_retry += 1
-                    continue            
+                    continue
                 if gen_req.status_code == 422:
-                    logger.error(
-                        f'KAI instance {self.bridge_data.kai_url} reported validation error.'
-                    )
+                    logger.error(f"KAI instance {self.bridge_data.kai_url} reported validation error.")
                     self.status = JobStatus.FAULTED
                     self.start_submit_thread()
                     return
                 try:
                     req_json = gen_req.json()
                 except json.decoder.JSONDecodeError:
-                    logger.error(f"Something went wrong when trying to generate on {self.bridge_data.kai_url}. Please check the health of the KAI worker. Retrying 3 seconds...")
+                    logger.error(
+                        (
+                            f"Something went wrong when trying to generate on {self.bridge_data.kai_url}. "
+                            "Please check the health of the KAI worker. Retrying 3 seconds...",
+                        ),
+                    )
                     loop_retry += 1
                     time.sleep(3)
                     continue
                 try:
                     self.text = req_json["results"][0]["text"]
                 except KeyError:
-                    logger.error(f"Unexpected response received from {self.bridge_data.kai_url}: {req_json}. Please check the health of the KAI worker. Retrying in 3 seconds...")
+                    logger.error(
+                        (
+                            f"Unexpected response received from {self.bridge_data.kai_url}: {req_json}. "
+                            "Please check the health of the KAI worker. Retrying in 3 seconds..."
+                        ),
+                    )
                     logger.debug(self.current_payload)
                     loop_retry += 1
                     time.sleep(3)
@@ -106,7 +126,7 @@ class ScribeHordeJob(HordeJobFramework):
             )
         except Exception as err:
             stack_payload = gen_payload
-            stack_payload["request_type"] = 'text2text'
+            stack_payload["request_type"] = "text2text"
             stack_payload["model"] = self.current_model
             stack_payload["prompt"] = "PROMPT REDACTED"
             logger.error(

--- a/worker/stats.py
+++ b/worker/stats.py
@@ -30,7 +30,9 @@ class BridgeStats:
             self.stats["inference"][model_name]["count"] += 1
             self.stats["inference"][model_name]["kudos"] = round(self.stats["inference"][model_name]["kudos"] + kudos)
             stats_for_model = self.stats["inference"][model_name]
-            self.stats["inference"][model_name]["avg_kpr"] = round(stats_for_model["kudos"] / stats_for_model["count"], 2)
+            self.stats["inference"][model_name]["avg_kpr"] = round(
+                stats_for_model["kudos"] / stats_for_model["count"], 2
+            )
 
             # Remember the kudos we got awarded over the last hour
             now = time.time()
@@ -44,10 +46,7 @@ class BridgeStats:
             # Calculate the total kudos
             total_kudos = sum(score for score, _ in self.kudos_record)
             # If period is less than an hour, extrapolate
-            if period < 10:
-                total_kudos = 0  # not enough measurements
-            else:
-                total_kudos = total_kudos * (3600 / period)
+            total_kudos = 0 if period < 10 else total_kudos * (3600 / period)
 
             if self.kudos_record:
                 self.stats["kudos_per_hour"] = round(total_kudos)

--- a/worker/stats.py
+++ b/worker/stats.py
@@ -1,8 +1,8 @@
 """Bridge Stats Tracker"""
 import json
+import threading
 import time
 from collections import deque
-import threading
 
 
 class BridgeStats:
@@ -31,7 +31,8 @@ class BridgeStats:
             self.stats["inference"][model_name]["kudos"] = round(self.stats["inference"][model_name]["kudos"] + kudos)
             stats_for_model = self.stats["inference"][model_name]
             self.stats["inference"][model_name]["avg_kpr"] = round(
-                stats_for_model["kudos"] / stats_for_model["count"], 2
+                stats_for_model["kudos"] / stats_for_model["count"],
+                2,
             )
 
             # Remember the kudos we got awarded over the last hour

--- a/worker/workers/framework.py
+++ b/worker/workers/framework.py
@@ -40,6 +40,7 @@ class WorkerFramework:
                 logger.warning("Terminal UI can not be enabled without also enabling 'always_download'")
             else:
                 from worker.ui import TerminalUI
+
                 ui = TerminalUI(self.bridge_data)
                 self.ui = threading.Thread(target=ui.run, daemon=True)
                 self.ui.start()
@@ -175,7 +176,10 @@ class WorkerFramework:
             return
 
         # Check periodically if any interesting stats should be announced
-        if self.bridge_data.stats_output_frequency and (time.time() - self.last_stats_time) > self.bridge_data.stats_output_frequency:
+        if (
+            self.bridge_data.stats_output_frequency
+            and (time.time() - self.last_stats_time) > self.bridge_data.stats_output_frequency
+        ):
             self.last_stats_time = time.time()
             logger.info(f"Estimated average kudos per hour: {bridge_stats.stats.get('kudos_per_hour', 0)}")
 

--- a/worker/workers/scribe.py
+++ b/worker/workers/scribe.py
@@ -1,12 +1,8 @@
 """This is the scribe worker, it's the main workhorse that deals with getting requests, and spawning data processing"""
-import traceback
-
-import requests
 import time
 
 from worker.jobs.poppers import ScribePopper
 from worker.jobs.scribe import ScribeHordeJob
-from worker.logger import logger
 from worker.workers.framework import WorkerFramework
 
 
@@ -25,7 +21,7 @@ class ScribeWorker(WorkerFramework):
 
     # We want this to be extendable as well
     def add_job_to_queue(self):
-        job = super().add_job_to_queue()
+        super().add_job_to_queue()
 
     def pop_job(self):
         return super().pop_job()


### PR DESCRIPTION
- Corrects the control net preloading to only occur when control_net is true in the worker config.
- Brings style/lint up to date with established rules.