### PR TITLE
Slim Docker Container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,3 +15,8 @@ nataili.dockerfile
 bridgeData.yaml
 /worker/conda/pkgs/
 /root/.cache/
+.git
+.gitattributes
+.gitignore
+.ruff_cache/
+nataili/

--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -18,6 +18,10 @@ jobs:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Free disk space
+      uses: jlumbroso/free-disk-space@main
+      with:
+        tool-cache: false
     - name: "Build and Publish Container to Github Container Registry"
       run: |
         docker build -t ghcr.io/db0/ai-horde-worker:${{ github.ref_name }} .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,4 @@
-FROM ubuntu
-
-ENV DEBIAN_FRONTEND=noninteractive
-
-RUN apt-get update && apt-get install -y \
-        ffmpeg \
-        libsm6 \
-        libxext6 \
-        wget
+FROM ubuntu:22.04
 
 RUN mkdir /worker
 
@@ -14,6 +6,16 @@ WORKDIR /worker
 
 COPY . .
 
-RUN ./update-runtime.sh
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y \
+        ffmpeg \
+        libsm6 \
+        libxext6 \
+        bzip2 \
+        wget \
+      && ./update-runtime.sh \
+      && rm -rf /var/lib/apt/lists/* \
+      && bin/micromamba run -r conda -n linux python -s -m pip cache purge
 
 ENTRYPOINT [ "/worker/docker_entrypoint.sh" ]


### PR DESCRIPTION
###### Overview
* Slimmed the docker container down from 22GB to 9.3 GB by deleting pip cache and removing apt cache
* Pegged docker container at 22.04 to prevent nasty surprises later when a major version upgrade happens
* Added free disk space github actions step to remove installed tools not necessary for our build in case the docker container build grows in size
* Tested the docker container locally and was able to pickup jobs from the horde and built in my own Github runner to test the remote build