### PR TITLE
feat: webui.py: Brings up to date with comfy, shows already downloaded models

### DIFF
--- a/bridgeData_template.yaml
+++ b/bridgeData_template.yaml
@@ -145,7 +145,7 @@ kai_url: "http://localhost:5000"
 max_length: 80
 # The max tokens to use from the prompt
 max_context_length: 1024
-# When set to true, the horde alias behing the API key will be appended to the model that is advertised to the horde
+# When set to true, the horde alias behind the API key will be appended to the model that is advertised to the horde
 # This will prevent the model from being used from the shared pool, but will ensure that no other worker
 # can pretend to serve it
 branded_model: true


### PR DESCRIPTION
- This brings the webui.py module up to date with the available options in the comfy branch.
  - This includes the VRAM/RAM free options, and the new Scribe options.
- Also shows already downloaded models.
  - If `AIWORKER_CACHE_HOME` is set, that is used. Direct users which use this environment variable to set it before invoking.
  - Otherwise, the working directory (`./`) is checked for a 'nataili' folder.
  - This is a mild convenience feature for users who may want to minimize disk space, but potentially have historically run features such as dynamic models.